### PR TITLE
Add Xdebug config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,51 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "pathMappings": {
+                "/var/www": "${workspaceRoot}"
+            }
+        },
+        {
+            "name": "Launch currently open script",
+            "type": "php",
+            "request": "launch",
+            "program": "${file}",
+            "cwd": "${fileDirname}",
+            "port": 0,
+            "runtimeArgs": [
+                "-dxdebug.start_with_request=yes"
+            ],
+            "env": {
+                "XDEBUG_MODE": "debug,develop",
+                "XDEBUG_CONFIG": "client_port=${port}"
+            }
+        },
+        {
+            "name": "Launch Built-in web server",
+            "type": "php",
+            "request": "launch",
+            "runtimeArgs": [
+                "-dxdebug.mode=debug",
+                "-dxdebug.start_with_request=yes",
+                "-S",
+                "localhost:0"
+            ],
+            "program": "",
+            "cwd": "${workspaceRoot}",
+            "port": 9003,
+            "serverReadyAction": {
+                "pattern": "Development Server \\(http://localhost:([0-9]+)\\) started",
+                "uriFormat": "http://localhost:%s",
+                "action": "openExternally"
+            }
+        }
+    ]
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -37,6 +37,7 @@ services:
       tty: true
       volumes: 
         - "./:/var/www"
+        - ./docker-php-ext-xdebug.ini:/usr/local/etc/php/php.ini 
         - "./log/apache:/var/log/apache2"
         - "./log/php:/srv/var/log"
 

--- a/docker-php-ext-xdebug.ini
+++ b/docker-php-ext-xdebug.ini
@@ -1,0 +1,9 @@
+# docker-php-ext-xdebug.ini
+zend_extension=xdebug
+xdebug.mode=develop,debug
+xdebug.start_with_request=yes
+xdebug.discover_client_host=1
+xdebug.start_upon_error=yes
+xdebug.client_host=host.docker.internal  
+xdebug.client_port=9003  
+xdebug.log="/var/log/xdebug.log"


### PR DESCRIPTION
Feature: Add Xdebug config to use Xdebug breakpoints.
- Added launch.json file.
- Added docker-php-ext-xdebug.ini file.
- Updated compose.yaml. file. 